### PR TITLE
Implement local ChatGPT chat page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # estagiario
+
 Companheiros de IA.
+
+## Local ChatGPT Interface
+
+Este projeto fornece uma interface simples de chat que se comunica com a API do ChatGPT.
+
+### Pré-requisitos
+- Node.js 16 ou superior
+- Uma chave de API da OpenAI salva em um arquivo `.env` como `OPENAI_API_KEY=SUACHAVE`
+
+### Instalação
+```bash
+npm install
+```
+
+### Execução
+```bash
+npm start
+```
+O servidor ficará disponível em `http://localhost:3000`.
+
+Acesse no navegador para utilizar o chat.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "estagiario-chat",
+  "version": "1.0.0",
+  "description": "Simple local chat UI communicating with ChatGPT API",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "openai": "^3.2.1",
+    "dotenv": "^16.0.3"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,34 @@
+document.getElementById('chat-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const promptInput = document.getElementById('prompt');
+  const message = promptInput.value.trim();
+  if (!message) return;
+
+  appendMessage('user', message);
+  promptInput.value = '';
+
+  try {
+    const response = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message })
+    });
+    const data = await response.json();
+    if (response.ok) {
+      appendMessage('bot', data.reply);
+    } else {
+      appendMessage('bot', data.error || 'Erro');
+    }
+  } catch (err) {
+    appendMessage('bot', 'Falha na comunicação com o servidor');
+  }
+});
+
+function appendMessage(role, text) {
+  const messages = document.getElementById('messages');
+  const div = document.createElement('div');
+  div.classList.add('message', role);
+  div.textContent = text;
+  messages.appendChild(div);
+  messages.scrollTop = messages.scrollHeight;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ChatGPT Local Chat</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="chat-container">
+    <div id="messages"></div>
+    <form id="chat-form">
+      <input type="text" id="prompt" placeholder="Digite sua mensagem" autocomplete="off" required>
+      <button type="submit">Enviar</button>
+    </form>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,38 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f4f4f4;
+  margin: 0;
+  padding: 0;
+}
+
+#chat-container {
+  width: 90%;
+  max-width: 600px;
+  margin: 30px auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+#messages {
+  height: 300px;
+  overflow-y: auto;
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+
+.message {
+  margin-bottom: 8px;
+}
+
+.message.user {
+  text-align: right;
+  color: blue;
+}
+
+.message.bot {
+  text-align: left;
+  color: green;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,33 @@
+require('dotenv').config();
+const express = require('express');
+const { Configuration, OpenAIApi } = require('openai');
+const path = require('path');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAIApi(configuration);
+
+app.post('/api/chat', async (req, res) => {
+  try {
+    const { message } = req.body;
+    if (!message) {
+      return res.status(400).json({ error: 'Message is required' });
+    }
+    const response = await openai.createChatCompletion({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: message }]
+    });
+    const reply = response.data.choices[0].message.content;
+    res.json({ reply });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to communicate with OpenAI API' });
+  }
+});
+
+app.listen(port, () => console.log(`Server listening on http://localhost:${port}`));


### PR DESCRIPTION
## Summary
- implement Express server to proxy ChatGPT API
- add simple HTML/CSS/JS chat frontend
- configure package.json and gitignore
- document setup and usage in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f68ddffa88328a5f26b9525adf376